### PR TITLE
Update python.mdx to use uv

### DIFF
--- a/docs/first-server/python.mdx
+++ b/docs/first-server/python.mdx
@@ -16,8 +16,15 @@ Let's build your first MCP server in Python! We'll create a weather server that 
     You'll need Python 3.10 or higher:
 
     ```bash
-    python --version  # Should be 3.9 or higher
+    python --version  # Should be 3.10 or higher
     pip --version
+    ```
+  </Step>
+
+  <Step title="Install uv (https://docs.astral.sh/uv/) via homebrew">
+    ```bash
+    brew install uv
+    uv --version # Should be 0.4.18 or higher
     ```
   </Step>
 


### PR DESCRIPTION
Use uv. 

In the quickstart we use a nice way to show how to setup requirements. Maybe we need to do that here @zckly  as well.