### PR TITLE
Update Python guide to use create-mcp-server

### DIFF
--- a/docs/first-server/python.mdx
+++ b/docs/first-server/python.mdx
@@ -33,17 +33,16 @@ Let's build your first MCP server in Python! We'll create a weather server that 
     ```
   </Step>
 
-  <Step title="Create a new project">
+  <Step title="Create a new project using the MCP project creator">
     ```bash
-    mkdir weather-service
-    cd weather-service
-    uv init --package --app --name weather-service
+    uvx create-mcp-server --path weather_service
+    cd weather_service
     ```
   </Step>
 
-  <Step title="Install dependencies">
+  <Step title="Install additional dependencies">
     ```bash
-    uv add mcp requests python-dotenv
+    uv add requests python-dotenv
     ```
   </Step>
 
@@ -59,13 +58,6 @@ Let's build your first MCP server in Python! We'll create a weather server that 
 ## Create your server
 
 <Steps>
-  <Step title="Create project structure">
-    ```bash
-    mkdir -p weather_service/src/weather_service
-    touch weather_service/src/weather_service/server.py
-    ```
-  </Step>
-
   <Step title="Add the base imports and setup">
   In `weather_service/src/weather_service/server.py`
   ```python


### PR DESCRIPTION
The guide now uses the official MCP project creator tool instead of manual project setup. This simplifies the initial setup process and ensures a consistent project structure, while still maintaining the same functionality.
