### PR TITLE
Remove `npm install -g` instruction

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -134,8 +134,12 @@ brew install node git sqlite3
         {
           "mcpServers": {
             "sqlite": {
-              "command": "mcp-server-sqlite",
-              "args": ["/Users/YOUR_USERNAME/test.db"]
+              "command": "uvx",
+              "args": [
+                "mcp-server-sqlite",
+                "--db-path",
+                "/Users/YOUR_USERNAME/test.db"
+              ]
             }
           }
         }
@@ -190,8 +194,12 @@ brew install node git sqlite3
         {
           "mcpServers": {
             "sqlite": {
-              "command": "mcp-server-sqlite",
-              "args": ["C:\\Users\\YOUR_USERNAME\\test.db"]
+              "command": "uvx",
+              "args": [
+                "mcp-server-sqlite",
+                "--db-path",
+                "C:\\Users\\YOUR_USERNAME\\test.db"
+              ]
             }
           }
         }


### PR DESCRIPTION
We actually need a `uvx` command for the sqlite server, to ask users to configure it in the following step. @dsp-ant Do you happen to have that command handy?