### PR TITLE
update tool response in typescript weather sample to be compliant with spec

### DIFF
--- a/docs/first-server/typescript.mdx
+++ b/docs/first-server/typescript.mdx
@@ -342,18 +342,18 @@ This guide uses the OpenWeatherMap API. You'll need a free API key from [OpenWea
             }
 
             return {
-              content: {
-                mimeType: "application/json",
+              content: [{
+                type: "text",
                 text: JSON.stringify(forecasts, null, 2)
-              }
+              }]
             };
           } catch (error) {
             if (axios.isAxiosError(error)) {
               return {
-                content: {
-                  mimeType: "text/plain",
+                content: [{
+                  type: "text",
                   text: `Weather API error: ${error.response?.data.message ?? error.message}`
-                },
+                }],
                 isError: true,
               }
             }


### PR DESCRIPTION
When running the weather typescript example with the code of the doc, Claude reports an error: `n.content.map is not a function` 

The error is due to the fact that the response to the tool request "get_forecast" is not compatible with the spec:
* content should be an array
* the mimeType is not supported as a text element, it should be type, and with the value text

Spec: https://spec.modelcontextprotocol.io/specification/server/tools/#tool-result

I checked the Python code and I see that the response is the same as the one that PR fixed:

```python
          return [
              TextContent(
                  type="text",
                  text=json.dumps(forecasts, indent=2)
              )
          ]
```          

FWIW, I documented the process to fix that issue here: https://pcarion.com/blog/claude_mcp/