### PR TITLE
Py first server docs: Add step to start MCP Server, rm env from server config

### DIFF
--- a/docs/first-server/python.mdx
+++ b/docs/first-server/python.mdx
@@ -285,11 +285,11 @@ Let's build your first MCP server in Python! We'll create a weather server that 
     __all__ = ['main', 'server']
     ```
   </Step>
-  <Step title="Start your new MCP server">
+  <Step title="Sync the venv for your new MCP server">
     From the root of your server project, run:
 
     ```bash
-    uv --directory . run weather-service
+    uv sync
     ```
     </Step>
 </Steps>

--- a/docs/first-server/python.mdx
+++ b/docs/first-server/python.mdx
@@ -285,6 +285,13 @@ Let's build your first MCP server in Python! We'll create a weather server that 
     __all__ = ['main', 'server']
     ```
   </Step>
+  <Step title="Start your new MCP server">
+    From the root of your server project, run:
+
+    ```bash
+    uv --directory . run weather-service
+    ```
+    </Step>
 </Steps>
 
 
@@ -307,9 +314,6 @@ Let's build your first MCP server in Python! We'll create a weather server that 
             "run",
             "weather-service"
           ],
-          "env": {
-            "OPENWEATHER_API_KEY": "your-api-key"
-          }
         }
       }
     }


### PR DESCRIPTION
1. Adds a step 7 to sync the MCP server for the first time
2. Removes the env piece from the server config for this tutorial since they should have already set up a `.env` file

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

Just two things I wrote down while working through the tutorial! A lot of ways to fix these inconsistencies of course (maybe leave the env example and add a note that you don't need a .env in that case? Could be the more comprehensive solution)

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Tested locally on my M1 Mac Mini.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

For the record, I was not able to get Claude Desktop to see my MCP server unless it was running the first time. It may not need to be running after that point. Probably more comprehensive ways to doc this so feel free to correct me! Thanks regardless for MCP and these docs, truly amazing stuff
