### PR TITLE
adding async to aenter in AsyncClient

### DIFF
--- a/docs/first-server/python.mdx
+++ b/docs/first-server/python.mdx
@@ -751,7 +751,7 @@ uvicorn.run(app, host="0.0.0.0", port=8000)
               return mock_forecast_response
 
       class AsyncClient():
-          def __aenter__(self):
+          async def __aenter__(self):
               return self
 
           async def __aexit__(self, *exc_info):


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

added async to the AsyncClient class that was missing, caused the test to fail with this error:

FAILED tests\weather_test.py::test_call_tool - TypeError: 'async with' received an object from __aenter__ that does not implement __await__: AsyncClient


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

Closes #64 

