### PR TITLE
Fix broken links in examples.mdx file

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -10,31 +10,31 @@ This page showcases various Model Context Protocol (MCP) servers that demonstrat
 These official reference servers demonstrate core MCP features and SDK usage:
 
 ### Data and file systems
-- **[Filesystem](src/filesystem)** - Secure file operations with configurable access controls
-- **[PostgreSQL](src/postgres)** - Read-only database access with schema inspection capabilities
-- **[SQLite](src/sqlite)** - Database interaction and business intelligence features
-- **[Google Drive](src/gdrive)** - File access and search capabilities for Google Drive
+- **[Filesystem](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem)** - Secure file operations with configurable access controls
+- **[PostgreSQL](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)** - Read-only database access with schema inspection capabilities
+- **[SQLite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite)** - Database interaction and business intelligence features
+- **[Google Drive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive)** - File access and search capabilities for Google Drive
 
 ### Development tools
-- **[Git](src/git)** - Tools to read, search, and manipulate Git repositories
-- **[GitHub](src/github)** - Repository management, file operations, and GitHub API integration
-- **[GitLab](src/gitlab)** - GitLab API integration enabling project management
-- **[Sentry](src/sentry)** - Retrieving and analyzing issues from Sentry.io
+- **[Git](https://github.com/modelcontextprotocol/servers/tree/main/src/git)** - Tools to read, search, and manipulate Git repositories
+- **[GitHub](https://github.com/modelcontextprotocol/servers/tree/main/src/github)** - Repository management, file operations, and GitHub API integration
+- **[GitLab](https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab)** - GitLab API integration enabling project management
+- **[Sentry](https://github.com/modelcontextprotocol/servers/tree/main/src/sentry)** - Retrieving and analyzing issues from Sentry.io
 
 ### Web and browser automation
-- **[Brave Search](src/brave-search)** - Web and local search using Brave's Search API
-- **[Fetch](src/fetch)** - Web content fetching and conversion optimized for LLM usage
-- **[Puppeteer](src/puppeteer)** - Browser automation and web scraping capabilities
+- **[Brave Search](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search)** - Web and local search using Brave's Search API
+- **[Fetch](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch)** - Web content fetching and conversion optimized for LLM usage
+- **[Puppeteer](https://github.com/modelcontextprotocol/servers/tree/main/src/puppeteer)** - Browser automation and web scraping capabilities
 
 ### Productivity and communication
-- **[Slack](src/slack)** - Channel management and messaging capabilities
-- **[Google Maps](src/google-maps)** - Location services, directions, and place details
-- **[Memory](src/memory)** - Knowledge graph-based persistent memory system
+- **[Slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)** - Channel management and messaging capabilities
+- **[Google Maps](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps)** - Location services, directions, and place details
+- **[Memory](https://github.com/modelcontextprotocol/servers/tree/main/src/memory)** - Knowledge graph-based persistent memory system
 
 ### AI and specialized tools
-- **[EverArt](src/everart)** - AI image generation using various models
-- **[Sequential Thinking](src/sequentialthinking)** - Dynamic problem-solving through thought sequences
-- **[AWS KB Retrieval](src/aws-kb-retrieval)** - Retrieval from AWS Knowledge Base using Bedrock Agent Runtime
+- **[EverArt](https://github.com/modelcontextprotocol/servers/tree/main/src/everart)** - AI image generation using various models
+- **[Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking)** - Dynamic problem-solving through thought sequences
+- **[AWS KB Retrieval](https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval)** - Retrieval from AWS Knowledge Base using Bedrock Agent Runtime
 
 ## Official integrations
 

--- a/examples.mdx
+++ b/examples.mdx
@@ -34,7 +34,7 @@ These official reference servers demonstrate core MCP features and SDK usage:
 ### AI and specialized tools
 - **[EverArt](https://github.com/modelcontextprotocol/servers/tree/main/src/everart)** - AI image generation using various models
 - **[Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking)** - Dynamic problem-solving through thought sequences
-- **[AWS KB Retrieval](https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval)** - Retrieval from AWS Knowledge Base using Bedrock Agent Runtime
+- **[AWS KB Retrieval](https://github.com/modelcontextprotocol/servers/tree/main/src/aws-kb-retrieval-server)** - Retrieval from AWS Knowledge Base using Bedrock Agent Runtime
 
 ## Official integrations
 


### PR DESCRIPTION
All the paths to the reference implementations were incorrect, so I have fixed them.