### PR TITLE
Add Cline client

### DIFF
--- a/clients.mdx
+++ b/clients.mdx
@@ -15,6 +15,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Firebase Genkit][Genkit] | ⚠️         | ✅         | ✅       | ❌          | ❌     | Supports resource list and lookup through tools.  |
 | [Continue][Continue]      | ✅         | ✅         | ✅       | ❌          | ❌     | Full support for all MCP features                 |
 | [GenAIScript][GenAIScript]  | ❌         | ❌         | ✅       | ❌          | ❌     | Supports tools. |
+| [Cline][Cline]      | ✅         | ❌         | ✅       | ❌          | ❌     | Supports tools and resources.                 |
 
 [Claude]: https://claude.ai/download
 [Zed]: https://zed.dev
@@ -22,6 +23,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Genkit]: https://github.com/firebase/genkit
 [Continue]: https://github.com/continuedev/continue
 [GenAIScript]: https://microsoft.github.io/genaiscript/reference/scripts/mcp-tools/
+[Cline]: https://github.com/cline/cline
 
 [Resources]: https://modelcontextprotocol.io/docs/concepts/resources
 [Prompts]: https://modelcontextprotocol.io/docs/concepts/prompts
@@ -84,6 +86,14 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - JavaScript toolbox to work with prompts
 - Abstraction to make it easy and productive
 - Seamless Visual Studio Code integration
+
+### Cline
+[Cline](https://github.com/cline/cline) is an autonomous coding agent in VS Code, with support for tools and resources.
+
+**Key features:**
+- Create tools through natural language (e.g. "add a tool that searches the web")
+- Displays connected MCP servers along with error logs to debug issues
+- Share custom MCP servers with others via the `~/Documents/Cline/MCP` directory
 
 ## Adding MCP support to your application
 

--- a/clients.mdx
+++ b/clients.mdx
@@ -88,12 +88,12 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Seamless Visual Studio Code integration
 
 ### Cline
-[Cline](https://github.com/cline/cline) is an autonomous coding agent in VS Code, with support for tools and resources.
+[Cline](https://github.com/cline/cline) is an autonomous coding agent in VS Code that edits files, runs commands, uses a browser, and more–with your permission at each step.
 
 **Key features:**
-- Create tools through natural language (e.g. "add a tool that searches the web")
-- Displays connected MCP servers along with error logs to debug issues
-- Share custom MCP servers with others via the `~/Documents/Cline/MCP` directory
+- Create and add tools through natural language (e.g. "add a tool that searches the web")
+- Share custom MCP servers Cline creates with others via the `~/Documents/Cline/MCP` directory
+- Displays configured MCP servers along with their tools, resources, and any error logs
 
 ## Adding MCP support to your application
 


### PR DESCRIPTION
Hi Anthropic! I'm excited to share I've just added MCP support to [Cline](https://github.com/cline/cline). Cline is a coding agent that can now respond to "add a tool that..." where he can extend his own capabilities by creating the necessary MCP server and configuring it in the extension, providing for a handsoff approach that I hope will make it easy for the community to contribute to your ecosystem. 

Here's a quick demo of MCP in Cline: https://x.com/sdrzn/status/1867271665086074969

Thank you for all your hard work in pushing MCP forward, I'm sure as we see wider adoption it will become more obvious to folks how much of a step change this is.

## Motivation and Context
Cline added MCP support and this PR updates the clients page.

## How Has This Been Tested?
Tested with `mintlify dev` ✅

## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
N/A