### PR TITLE
Add Development section with Contributing and Roadmap pages

### DIFF
--- a/development/contributing.mdx
+++ b/development/contributing.mdx
@@ -1,0 +1,10 @@
+---
+title: Contributing
+description: How to participate in Model Context Protocol development
+---
+
+We welcome contributions from the community! Please review our [contributing guidelines](https://github.com/modelcontextprotocol/.github/blob/main/CONTRIBUTING.md) for details on how to submit changes.
+
+All contributors must adhere to our [Code of Conduct](https://github.com/modelcontextprotocol/.github/blob/main/CODE_OF_CONDUCT.md).
+
+For questions and discussions, please use [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions).

--- a/development/roadmap.mdx
+++ b/development/roadmap.mdx
@@ -1,0 +1,57 @@
+---
+title: Roadmap
+description: Our plans for evolving Model Context Protocol
+---
+
+The Model Context Protocol is rapidly evolving. This page outlines our current thinking on key priorities and future direction, though these may change significantly as the project develops.
+
+<Note>The ideas presented here are not commitments—we may solve these challenges differently than described, or some may not materialize at all.</Note>
+
+We encourage community participation! Each section links to relevant discussions where you can learn more and contribute your thoughts.
+
+## Remote MCP Support
+
+Our top priority is enabling [remote MCP connections](https://github.com/modelcontextprotocol/specification/discussions/102), allowing clients to securely connect to MCP servers over the internet. Key initiatives include:
+
+- [**Authentication & Authorization**](https://github.com/modelcontextprotocol/specification/discussions/64): Adding standardized auth capabilities, particularly focused on OAuth 2.0 support.
+
+- [**Service Discovery**](https://github.com/modelcontextprotocol/specification/discussions/69): Defining how clients can discover and connect to remote MCP servers, perhaps through a mechanism like a well known URI for MCP.
+
+- [**Stateless Operations**](https://github.com/modelcontextprotocol/specification/discussions/102): Ensuring MCP servers can operate in serverless environments, where they will need to be mostly stateless.
+
+## Reference Implementations
+
+To help developers build with MCP, we want to offer documentation for:
+
+- **Client Examples**: Comprehensive reference client implementation(s), demonstrating all protocol features
+- **Protocol Drafting**: Streamlined process for proposing and incorporating new protocol features
+
+## Distribution & Discovery
+
+Looking ahead, we're exploring ways to make MCP servers more accessible. Some areas we may investigate include:
+
+- **Package Management**: Standardized packaging format for MCP servers
+- **Installation Tools**: Simplified server installation across MCP clients
+- **Sandboxing**: Improved security through server isolation
+- **Server Registry**: A common directory for discovering available MCP servers
+
+## Agent Support
+
+We're expanding MCP's capabilities for [complex agentic workflows](https://github.com/modelcontextprotocol/specification/discussions/111), particularly focusing on:
+
+- [**Hierarchical Agent Systems**](https://github.com/modelcontextprotocol/specification/discussions/94): Improved support for trees of agents through namespacing and topology awareness.
+
+- [**Interactive Workflows**](https://github.com/modelcontextprotocol/specification/issues/97): Better handling of user permissions and information requests across agent hierarchies, and ways to send output to users instead of models.
+
+- [**Streaming Results**](https://github.com/modelcontextprotocol/specification/issues/117): Real-time updates from long-running agent operations.
+
+## Broader Ecosystem
+
+We're also invested in:
+
+- **Community-Led Standards Development**: Fostering a collaborative ecosystem where all AI providers can help shape MCP as an open standard through equal participation and shared governance, ensuring it meets the needs of diverse AI applications and use cases.
+- [**Additional Modalities**](https://github.com/modelcontextprotocol/specification/discussions/88): Expanding beyond text to support audio, video, and other formats.
+
+## Get Involved
+
+We welcome community participation in shaping MCP's future. Visit our [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions) to join the conversation and contribute your ideas.

--- a/development/roadmap.mdx
+++ b/development/roadmap.mdx
@@ -15,7 +15,7 @@ Our top priority is enabling [remote MCP connections](https://github.com/modelco
 
 - [**Authentication & Authorization**](https://github.com/modelcontextprotocol/specification/discussions/64): Adding standardized auth capabilities, particularly focused on OAuth 2.0 support.
 
-- [**Service Discovery**](https://github.com/modelcontextprotocol/specification/discussions/69): Defining how clients can discover and connect to remote MCP servers, perhaps through a mechanism like a well known URI for MCP.
+- [**Service Discovery**](https://github.com/modelcontextprotocol/specification/discussions/69): Defining how clients can discover and connect to remote MCP servers.
 
 - [**Stateless Operations**](https://github.com/modelcontextprotocol/specification/discussions/102): Ensuring MCP servers can operate in serverless environments, where they will need to be mostly stateless.
 
@@ -51,6 +51,7 @@ We're also invested in:
 
 - **Community-Led Standards Development**: Fostering a collaborative ecosystem where all AI providers can help shape MCP as an open standard through equal participation and shared governance, ensuring it meets the needs of diverse AI applications and use cases.
 - [**Additional Modalities**](https://github.com/modelcontextprotocol/specification/discussions/88): Expanding beyond text to support audio, video, and other formats.
+- [**Standardization**] Considering standardization through a standardization body.
 
 ## Get Involved
 

--- a/development/roadmap.mdx
+++ b/development/roadmap.mdx
@@ -5,7 +5,7 @@ description: Our plans for evolving Model Context Protocol (H1 2025)
 
 The Model Context Protocol is rapidly evolving. This page outlines our current thinking on key priorities and future direction for **the first half of 2025**, though these may change significantly as the project develops.
 
-<Note>The ideas presented here are not commitments—we may solve these challenges differently than described, or some may not materialize at all.</Note>
+<Note>The ideas presented here are not commitments—we may solve these challenges differently than described, or some may not materialize at all. This is also not an _exhaustive_ list; we may incorporate work that isn't mentioned here.</Note>
 
 We encourage community participation! Each section links to relevant discussions where you can learn more and contribute your thoughts.
 
@@ -17,7 +17,7 @@ Our top priority is enabling [remote MCP connections](https://github.com/modelco
 
 - [**Service Discovery**](https://github.com/modelcontextprotocol/specification/discussions/69): Defining how clients can discover and connect to remote MCP servers.
 
-- [**Stateless Operations**](https://github.com/modelcontextprotocol/specification/discussions/102): Ensuring MCP servers can operate in serverless environments, where they will need to be mostly stateless.
+- [**Stateless Operations**](https://github.com/modelcontextprotocol/specification/discussions/102): Thinking about whether MCP could encompass serverless environments too, where they will need to be mostly stateless.
 
 ## Reference Implementations
 

--- a/development/roadmap.mdx
+++ b/development/roadmap.mdx
@@ -1,9 +1,9 @@
 ---
 title: Roadmap
-description: Our plans for evolving Model Context Protocol
+description: Our plans for evolving Model Context Protocol (H1 2025)
 ---
 
-The Model Context Protocol is rapidly evolving. This page outlines our current thinking on key priorities and future direction, though these may change significantly as the project develops.
+The Model Context Protocol is rapidly evolving. This page outlines our current thinking on key priorities and future direction for **the first half of 2025**, though these may change significantly as the project develops.
 
 <Note>The ideas presented here are not commitments—we may solve these challenges differently than described, or some may not materialize at all.</Note>
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -151,4 +151,4 @@ Dive deeper into MCP's core concepts and capabilities:
 
 ## Contributing
 
-Want to contribute? Check out [@modelcontextprotocol](https://github.com/modelcontextprotocol) on GitHub to join our growing community of developers building with MCP.
+Want to contribute? Check out our [Contributing Guide](/development/contributing) to learn how you can help improve MCP.

--- a/mint.json
+++ b/mint.json
@@ -40,7 +40,12 @@
   "navigation": [
     {
       "group": "Get Started",
-      "pages": ["introduction", "quickstart", "examples", "clients"]
+      "pages": [
+        "introduction",
+        "quickstart",
+        "examples",
+        "clients"
+      ]
     },
     {
       "group": "Tutorials",
@@ -60,6 +65,12 @@
         "docs/concepts/tools",
         "docs/concepts/sampling",
         "docs/concepts/transports"
+      ]
+    },
+    {
+      "group": "Development",
+      "pages": [
+        "development/contributing"
       ]
     }
   ],

--- a/mint.json
+++ b/mint.json
@@ -70,6 +70,7 @@
     {
       "group": "Development",
       "pages": [
+        "development/roadmap",
         "development/contributing"
       ]
     }


### PR DESCRIPTION
Added a roadmap page (something frequently requested) which outlines our proposed H1 2025 priorities. I think this is mostly reflective of how we've been thinking about it, but please chime in if any of it seems wrong!