### PR TITLE
docs: Add LibreChat Client

### DIFF
--- a/clients.mdx
+++ b/clients.mdx
@@ -16,6 +16,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [Continue][Continue]      | ✅         | ✅         | ✅       | ❌          | ❌     | Full support for all MCP features                 |
 | [GenAIScript][GenAIScript]  | ❌         | ❌         | ✅       | ❌          | ❌     | Supports tools. |
 | [Cline][Cline]      | ✅         | ❌         | ✅       | ❌          | ❌     | Supports tools and resources.                 |
+| [LibreChat][LibreChat]     | ❌         | ❌         | ✅       | ❌          | ❌     | Supports tools for Agents    |
 
 [Claude]: https://claude.ai/download
 [Zed]: https://zed.dev
@@ -24,6 +25,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Continue]: https://github.com/continuedev/continue
 [GenAIScript]: https://microsoft.github.io/genaiscript/reference/scripts/mcp-tools/
 [Cline]: https://github.com/cline/cline
+[LibreChat]: https://github.com/danny-avila/LibreChat
 
 [Resources]: https://modelcontextprotocol.io/docs/concepts/resources
 [Prompts]: https://modelcontextprotocol.io/docs/concepts/prompts
@@ -94,6 +96,15 @@ Programmatically assemble prompts for LLMs using [GenAIScript](https://microsoft
 - Create and add tools through natural language (e.g. "add a tool that searches the web")
 - Share custom MCP servers Cline creates with others via the `~/Documents/Cline/MCP` directory
 - Displays configured MCP servers along with their tools, resources, and any error logs
+
+### LibreChat
+[LibreChat](https://github.com/danny-avila/LibreChat) is an open-source, customizable AI chat UI that supports multiple AI providers, now including MCP integration.
+
+**Key features:**
+- Extend current tool ecosystem, including [Code Interpreter](https://www.librechat.ai/docs/features/code_interpreter) and Image generation tools, through MCP servers
+- Add tools to customizable [Agents](https://www.librechat.ai/docs/features/agents), using a variety of LLMs from top providers
+- Open-source and self-hostable, with secure multi-user support
+- Future roadmap includes expanded MCP feature support
 
 ## Adding MCP support to your application
 


### PR DESCRIPTION
## Motivation and Context
I'm adding [LibreChat](https://github.com/danny-avila/LibreChat) to the list of applications supporting the Model Context Protocol (MCP), highlighting its new integration capabilities.

## How Has This Been Tested?

- Reviewed documentation for technical correctness

## Breaking Changes
- None. This is a documentation update only.

## Types of changes
- [x] Documentation update

## Checklist
- [x] Updated client details reflect current LibreChat capabilities
- [x] Information is technically accurate
- [x] Maintained consistent documentation style
- [x] Added links to relevant LibreChat documentation

## Additional context
This update provides potential users and developers with insight into LibreChat's MCP support, emphasizing our commitment to open, extensible AI tooling.