### PR TITLE
Simplify logging comment in TypeScript first server guide

### DIFF
--- a/docs/tools/debugging.mdx
+++ b/docs/tools/debugging.mdx
@@ -80,6 +80,23 @@ Use the Network panel to inspect:
 
 ## Common issues
 
+### Working directory
+
+When using MCP servers with Claude Desktop:
+
+- The working directory for servers launched via `claude_desktop_config.json` may be undefined (like `/` on macOS) since Claude Desktop could be started from anywhere
+- Always use absolute paths in your configuration and `.env` files to ensure reliable operation
+- For testing servers directly via command line, the working directory will be where you run the command
+
+For example in `claude_desktop_config.json`, use:
+```json
+{
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/Users/username/data"]
+}
+```
+Instead of relative paths like `./data`
+
 ### Environment variables
 
 MCP servers inherit only a subset of environment variables automatically, like `USER`, `HOME`, and `PATH`.


### PR DESCRIPTION
## Summary
- Add documentation about working directory behavior for MCP servers
- Clarify that working directory is undefined when launched via Claude Desktop
- Add guidance to use absolute paths in configuration files

## Test plan
- Verify documentation is clear and accurate
- Check that example configuration uses absolute paths
- Ensure guidance helps users avoid working directory issues