### PR TITLE
Added a Warning to "User Quickstart" to remind the User to only add trusted commands

### DIFF
--- a/quickstart/user.mdx
+++ b/quickstart/user.mdx
@@ -104,7 +104,7 @@ This configuration file tells Claude for Dekstop which MCP servers to start up e
 <Warning>
 **Command Privileges**
 
-Claude for Desktop will run the commands in the configuration file at the current User Privilege level. Only add commands if you understand and trust the source.
+Claude for Desktop will run the commands in the configuration file with the permissions of your user account, and access to your local files. Only add commands if you understand and trust the source.
 </Warning>
 
 ## 3. Restart Claude

--- a/quickstart/user.mdx
+++ b/quickstart/user.mdx
@@ -101,6 +101,12 @@ If you get an error saying "command not found" or "node is not recognized", down
 This configuration file tells Claude for Dekstop which MCP servers to start up every time you start the application. In this case, we have added one server called "filesystem" that will use the Node `npx` command to install and run `@modelcontextprotocol/server-filesystem`. This server, described [here](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem), will let you access your file system in Claude for Desktop.
 </Tip>
 
+<Warning>
+**Command Privileges**
+
+Claude for Desktop will run the commands in the configuration file at the current User Privilege level. Only add commands if you understand and trust the source.
+</Warning>
+
 ## 3. Restart Claude
 
 After updating your configuration file, you need to restart Claude for Desktop.


### PR DESCRIPTION
Added a Warning box to the User QuickStart guide to remind people to only add trusted commands.

## Motivation and Context

To remind users to verify commands added to the Configuration File as by design Claude Desktop will execute arbitrary commands at the current privilege level. 

Other mentions of "security" in this guide tend to reinforce that the MCP is secure potentially giving false reassurance.

## How Has This Been Tested?

Using mintlify as per the contributing guidelines.

## Breaking Changes

No.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed

## Additional context
