### PR TITLE
Added warning regarding the uv command in the quickstart guide

### DIFF
--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -301,6 +301,10 @@ In this case, we'll add our single weather server like so:
 </Tab>
 </Tabs>
 
+<Warning>
+You may need to put the full path to the `uv` executable in the `command` field. You can get this by running `which uv` on MacOS/Linux or `where uv` on Windows.
+</Warning>
+
 <Note>
 Make sure you pass in the absolute path to your server.
 </Note>


### PR DESCRIPTION
Added warning to help with https://github.com/modelcontextprotocol/docs/issues/96

## Motivation and Context
People are hitting issues with paths, this should give people some breadcrumbs to follow to fix issues in the quickstart

## How Has This Been Tested?
Tested locally 
![CleanShot 2025-01-03 at 15 36 48@2x](https://github.com/user-attachments/assets/8348cd41-1a8a-4006-a567-46eb37481117)


## Breaking Changes
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

