### PR TITLE
docs: Update Python quickstart to use FastMCP API

### DIFF
--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -111,79 +111,23 @@ Now let's dive into building your server.
 
 ## Building your server
 
-### Importing packages
+### Importing packages and setting up the instance
 
-Add these to the top of your `server.py`:
+Add these to the top of your `weather.py`:
 ```python
 from typing import Any
-import asyncio
 import httpx
-from mcp.server.models import InitializationOptions
-import mcp.types as types
-from mcp.server import NotificationOptions, Server
-import mcp.server.stdio
-```
+from mcp.server.fastmcp import FastMCP
 
-### Setting up the instance
+# Initialize FastMCP server
+mcp = FastMCP("weather")
 
-Then initialize the server instance and the base URL for the NWS API:
-
-```python
+# Constants
 NWS_API_BASE = "https://api.weather.gov"
 USER_AGENT = "weather-app/1.0"
-
-server = Server("weather")
 ```
 
-### Implementing tool listing
-
-We need to tell clients what tools are available. The `list_tools()` decorator registers this handler:
-
-```python
-@server.list_tools()
-async def handle_list_tools() -> list[types.Tool]:
-    """
-    List available tools.
-    Each tool specifies its arguments using JSON Schema validation.
-    """
-    return [
-        types.Tool(
-            name="get-alerts",
-            description="Get weather alerts for a state",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "state": {
-                        "type": "string",
-                        "description": "Two-letter state code (e.g. CA, NY)",
-                    },
-                },
-                "required": ["state"],
-            },
-        ),
-        types.Tool(
-            name="get-forecast",
-            description="Get weather forecast for a location",
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "latitude": {
-                        "type": "number",
-                        "description": "Latitude of the location",
-                    },
-                    "longitude": {
-                        "type": "number",
-                        "description": "Longitude of the location",
-                    },
-                },
-                "required": ["latitude", "longitude"],
-            },
-        ),
-    ]
-
-```
-
-This defines our two tools: `get-alerts` and `get-forecast`.
+The new FastMCP class provides a simpler, more intuitive API. Instead of manually defining tool schemas, we can use Python type hints and docstrings to automatically generate the tool definitions.
 
 ### Helper functions
 

--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -74,7 +74,7 @@ Now, let's create and set up our project:
 <CodeGroup>
 ```bash MacOS/Linux
 # Create a new directory for our project
-uv init weather
+mkdir weather
 cd weather
 
 # Create virtual environment and activate it
@@ -82,20 +82,15 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv add mcp httpx 
+uv add "mcp[cli]" httpx
 
-# Remove template file
-rm hello.py
-
-# Create our files
-mkdir -p src/weather
-touch src/weather/__init__.py
-touch src/weather/server.py
+# Create our server file
+touch weather.py
 ```
 
 ```powershell Windows
 # Create a new directory for our project
-uv init weather
+md weather
 cd weather
 
 # Create virtual environment and activate it
@@ -103,45 +98,14 @@ uv venv
 .venv\Scripts\activate
 
 # Install dependencies
-uv add mcp httpx
+uv add "mcp[cli]" httpx
 
-# Clean up boilerplate code
-rm hello.py
-
-# Create our files
-md src
-md src\weather
-new-item src\weather\__init__.py
-new-item src\weather\server.py
+# Create our server file
+new-item weather.py
 ```
 </CodeGroup>
 
-Add this code to `pyproject.toml`:
-
-```toml
-...rest of config
-
-[build-system]
-requires = [ "hatchling",]
-build-backend = "hatchling.build"
-
-[project.scripts]
-weather = "weather:main"
-```
-
-Add this code to `__init__.py`:
-
-```python src/weather/__init__.py
-from . import server
-import asyncio
-
-def main():
-    """Main entry point for the package."""
-    asyncio.run(server.main())
-
-# Optionally expose other important items at package level
-__all__ = ['main', 'server']
-```
+The new Python SDK uses a simpler project structure with a single file. We'll create a `weather.py` file that will contain our server implementation.
 
 Now let's dive into building your server.
 


### PR DESCRIPTION
This PR updates the Python quickstart guide to use the new FastMCP API. Key changes:

- Updates code examples to use FastMCP class instead of manual tool definitions
- Improves error handling and response formatting
- Adds system requirements section
- Fixes formatting and whitespace

Test plan:
- [ ] Verify all code examples are complete and correct
- [ ] Test the weather server implementation locally
- [ ] Check formatting and links