### PR TITLE
quickstart: Use quotes to avoid shell interpretation for `uv add mcp[cli]`

### DIFF
--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -83,7 +83,7 @@ uv venv
 source .venv/bin/activate
 
 # Install dependencies
-uv add mcp[cli] httpx
+uv add "mcp[cli]" httpx
 
 # Create our server file
 touch weather.py


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Use quotes to avoid shell interpretation; i.e. `uv add "mcp[cli]"` instead of `uv add mcp[cli]`

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

The document says to run `uv add mcp[cli]` but it causes an error on Mac/Linux due to the shell interpretation of `[]`

This is a one-line PR to fix the issue and allow the reader to simply cut and paste the command.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

The updated file has been verified with `mintlify dev`

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
Thanks for taking care of this!