### PR TITLE
docs: add server initialization instructions to quickstart guide

### DIFF
--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -220,6 +220,16 @@ Forecast: {period['detailedForecast']}
     return "\n---\n".join(forecasts)
 ```
 
+### Running the server
+
+Finally, let's initialize and run the server:
+
+```python
+if __name__ == "__main__":
+    # Initialize and run the server
+    mcp.run(transport='stdio')
+```
+
 Your server is complete! Run `uv run weather.py` to confirm that everything's working.
 
 Let's now test your server from an existing MCP host, Claude for Desktop.
@@ -230,7 +240,7 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/quickstart/client) tutorial to build an MCP client that connects to the server we just built.
 </Note>
 
-First, make sure you have Claude for Desktop installed. [You can install the latest version 
+First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -297,7 +307,7 @@ Make sure you pass in the absolute path to your server.
 
 This tells Claude for Desktop:
 1. There's an MCP server named "weather"
-2. To launch it by running `uv --directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/weather run weather` 
+2. To launch it by running `uv --directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/weather run weather`
 
 Save the file, and restart **Claude for Desktop**.
 </Tab>
@@ -402,7 +412,7 @@ Create a `tsconfig.json` in the root of your project:
 
 Now let's dive into building your server.
 
-## Building your server 
+## Building your server
 
 ### Importing packages
 
@@ -752,7 +762,7 @@ Let's now test your server from an existing MCP host, Claude for Desktop.
 Claude for Desktop is not yet available on Linux. Linux users can proceed to the [Building a client](/quickstart/client) tutorial to build an MCP client that connects to the server we just built.
 </Note>
 
-First, make sure you have Claude for Desktop installed. [You can install the latest version 
+First, make sure you have Claude for Desktop installed. [You can install the latest version
 here.](https://claude.ai/download) If you already have Claude for Desktop, **make sure it's updated to the latest version.**
 
 We'll need to configure Claude for Desktop for whichever MCP servers you want to use. To do this, open your Claude for Desktop App configuration at `~/Library/Application Support/Claude/claude_desktop_config.json` in a text editor. Make sure to create the file if it doesn't exist.
@@ -779,7 +789,7 @@ In this case, we'll add our single weather server like so:
 <Tabs>
 <Tab title="MacOS/Linux">
 <CodeGroup>
-```json Node 
+```json Node
 {
     "mcpServers": {
         "weather": {
@@ -851,7 +861,7 @@ If the hammer icon has shown up, you can now test your server by running the fol
 Since this is the US National Weather service, the queries will only work for US locations.
 </Note>
 
-## What's happening under the hood 
+## What's happening under the hood
 
 When you ask a question:
 


### PR DESCRIPTION
## Summary
- Add missing server initialization instructions to Python quickstart guide
- Clean up formatting and whitespace in server.mdx

## Test plan
- [ ] Verify code examples are complete and properly formatted
- [ ] Confirm server initialization instructions are clear and accurate
- [ ] Check that documentation builds successfully