### PR TITLE
fix: trailing '`' breaks MacOS/Linux cli example for "quickstart/user#server-not-showing-up-in-claude-hammer-icon-missing"

### DIFF
--- a/quickstart/user.mdx
+++ b/quickstart/user.mdx
@@ -145,7 +145,7 @@ As needed, Claude will call the relevant tools and seek your approval before tak
 <Tabs>
 <Tab title="MacOS/Linux">
 ```bash
-npx -y @modelcontextprotocol/server-filesystem /Users/username/Desktop /Users/username/Downloads`
+npx -y @modelcontextprotocol/server-filesystem /Users/username/Desktop /Users/username/Downloads
 ```
 </Tab>
 <Tab title="Windows">


### PR DESCRIPTION
Fixing trailing `` ` `` breaks MacOS/Linux cli example for "https://modelcontextprotocol.io/quickstart/user#server-not-showing-up-in-claude-hammer-icon-missing" in issue [#105](https://github.com/modelcontextprotocol/docs/issues/105)

## Motivation and Context
Although it's a minor issue, may confuse more novice users

## How Has This Been Tested?
1. Running `mintlify dev`
2. Navigating to the section [https://modelcontextprotocol.io/quickstart/user#server-not-showing-up-in-claude-hammer-icon-missing](https://modelcontextprotocol.io/quickstart/user#server-not-showing-up-in-claude-hammer-icon-missing)
3. copying the code for the `MacOS/Linux` tab
4. pasting the command in the terminal and pressing `Enter`

## Breaking Changes
none

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Before the change, running the code sample displayed:
```
) npx -y @modelcontextprotocol/server-filesystem /Users/username/Desktop /Users/username/Downloads`

>
```

After the change, clicking copy n' paste and running the code sample results with:
```
) npx -y @modelcontextprotocol/server-filesystem /Users/username/Desktop /Users/username/Downloads
Secure MCP Filesystem Server running on stdio
Allowed directories: [ '/users/username/desktop', '/users/username/downloads' ]
```
