### PR TITLE
Debugging page: adjust one-liner to create developer_settings.json file if necessary

### DIFF
--- a/docs/tools/debugging.mdx
+++ b/docs/tools/debugging.mdx
@@ -63,7 +63,7 @@ Access Chrome's developer tools inside Claude Desktop to investigate client-side
 1. Create a `developer_settings.json` file with `allowDevTools` set to true:
 
 ```bash
-echo '{"allowDevTools": true }' > ~/Library/Application\ Support/Claude/developer_settings.json
+echo '{"allowDevTools": true}' > ~/Library/Application\ Support/Claude/developer_settings.json
 ```
 
 2. Open DevTools: `Command-Option-Shift-i`

--- a/docs/tools/debugging.mdx
+++ b/docs/tools/debugging.mdx
@@ -60,10 +60,13 @@ The logs capture:
 
 Access Chrome's developer tools inside Claude Desktop to investigate client-side errors:
 
-1. Enable DevTools:
+1. Enable the `allowDevTools` flag in your `developer_settings.json` file:
+
 ```bash
-jq '.allowDevTools = true' ~/Library/Application\ Support/Claude/developer_settings.json > tmp.json \
-  && mv tmp.json ~/Library/Application\ Support/Claude/developer_settings.json
+[ -s ~/Library/Application\ Support/Claude/developer_settings.json ] \
+   && jq '.allowDevTools = true' ~/Library/Application\ Support/Claude/developer_settings.json > tmp.json \
+   || echo '{"allowDevTools": true}' > tmp.json \
+   && mv tmp.json ~/Library/Application\ Support/Claude/developer_settings.json
 ```
 
 2. Open DevTools: `Command-Option-Shift-i`

--- a/docs/tools/debugging.mdx
+++ b/docs/tools/debugging.mdx
@@ -63,7 +63,7 @@ Access Chrome's developer tools inside Claude Desktop to investigate client-side
 1. Create a `developer_settings.json` file with `allowDevTools` set to true:
 
 ```bash
-echo '{"allow_dev_tools": true }' > ~/Library/Application\ Support/Claude/developer_settings.json
+echo '{"allowDevTools": true }' > ~/Library/Application\ Support/Claude/developer_settings.json
 ```
 
 2. Open DevTools: `Command-Option-Shift-i`

--- a/docs/tools/debugging.mdx
+++ b/docs/tools/debugging.mdx
@@ -60,13 +60,10 @@ The logs capture:
 
 Access Chrome's developer tools inside Claude Desktop to investigate client-side errors:
 
-1. Enable the `allowDevTools` flag in your `developer_settings.json` file:
+1. Create a `developer_settings.json` file with `allowDevTools` set to true:
 
 ```bash
-[ -s ~/Library/Application\ Support/Claude/developer_settings.json ] \
-   && jq '.allowDevTools = true' ~/Library/Application\ Support/Claude/developer_settings.json > tmp.json \
-   || echo '{"allowDevTools": true}' > tmp.json \
-   && mv tmp.json ~/Library/Application\ Support/Claude/developer_settings.json
+echo '{"allow_dev_tools": true }' > ~/Library/Application\ Support/Claude/developer_settings.json
 ```
 
 2. Open DevTools: `Command-Option-Shift-i`


### PR DESCRIPTION
A stock install of Claude Desktop doesn't seem to have a `developer_settings.json` file, so the setup instructions for Chrome Dev Tools on the Debugging are incomplete.

This adjusts

## Motivation and Context

See above. Note this does not fix the unspoken dependency on `jq`, and like a lot of things in the docs, is currently Mac-specific

## How Has This Been Tested?

I'm on a Mac with jq. I've tested it with the file missing, the file present w/ my own changes, and the file present but empty

## Breaking Changes

Nothing

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Love MCP so far, keep up the great work, will keep the docs PRs coming if welcome :)