### PR TITLE
Fix example for implementing SSE Server in TypeScript

### DIFF
--- a/docs/concepts/transports.mdx
+++ b/docs/concepts/transports.mdx
@@ -126,15 +126,30 @@ Use SSE when:
 <Tabs>
   <Tab title="TypeScript (Server)">
     ```typescript
+    import express from "express";
+    
+    let transport: SSEServerTransport | null = null;
+    const app = express();
+    
     const server = new Server({
       name: "example-server",
       version: "1.0.0"
     }, {
       capabilities: {}
     });
+    
+    app.get("/sse", (req, res) => {
+		  transport = new SSEServerTransport("/messages", res);
+		  server.connect(transport);
+	  });
 
-    const transport = new SSEServerTransport("/message", response);
-    await server.connect(transport);
+    app.post("/messages", (req, res) => {
+		  if (transport) {
+			  transport.handlePostMessage(req, res);
+		  }
+	  });
+
+	  app.listen(3000);
     ```
   </Tab>
   <Tab title="TypeScript (Client)">

--- a/docs/concepts/transports.mdx
+++ b/docs/concepts/transports.mdx
@@ -128,7 +128,6 @@ Use SSE when:
     ```typescript
     import express from "express";
     
-    let transport: SSEServerTransport | null = null;
     const app = express();
     
     const server = new Server({
@@ -138,18 +137,20 @@ Use SSE when:
       capabilities: {}
     });
     
+    let transport: SSEServerTransport | null = null;
+
     app.get("/sse", (req, res) => {
-		  transport = new SSEServerTransport("/messages", res);
-		  server.connect(transport);
-	  });
+      transport = new SSEServerTransport("/messages", res);
+      server.connect(transport);
+    });
 
     app.post("/messages", (req, res) => {
-		  if (transport) {
-			  transport.handlePostMessage(req, res);
-		  }
-	  });
+      if (transport) {
+        transport.handlePostMessage(req, res);
+      }
+    });
 
-	  app.listen(3000);
+    app.listen(3000);
     ```
   </Tab>
   <Tab title="TypeScript (Client)">


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

I was working through implementing an SSE server in TypeScript, and this is the current example:

```typescript
const server = new Server({
  name: "example-server",
  version: "1.0.0"
}, {
  capabilities: {}
});

const transport = new SSEServerTransport("/message", response);
await server.connect(transport);
```

It is unclear what `response` is meant to be here, and this seems to be just the definition for the `GET` part of the connection (there no mention of `transport.handlePostMessage`).

The example I've created has close parity with the equivalent Python example (using `express` as an analog to `Starlette`).

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

I tested the code while working on my server [here](https://github.com/tadasant/mcp-server-stability-ai/blob/6c906e28f43527cdb563bcf4f57c524b8b4dbc37/src/sse.ts) by connecting to it with [wong2's CLI tool](https://github.com/wong2/mcp-cli), and trying a request/response successfully.

I've run the docs UI locally with mintlify and it looks well-formatted:

![CleanShot 2025-01-16 at 00 55 40@2x](https://github.com/user-attachments/assets/2537b029-cd8c-4437-89a2-5c180db29e77)

## Breaking Changes

None.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
