### PR TITLE
Makes PowerShell Usage Explicit

### DIFF
--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -62,7 +62,7 @@ First, let's install `uv` and set up our Python project and environment:
 curl -LsSf https://astral.sh/uv/install.sh | sh
 ```
 
-```powershell Windows
+```powershell Windows (PowerShell)
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
 ```
 
@@ -89,7 +89,7 @@ uv add "mcp[cli]" httpx
 touch weather.py
 ```
 
-```powershell Windows
+```powershell Windows (PowerShell)
 # Create a new directory for our project
 uv init weather
 cd weather
@@ -253,7 +253,7 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 </Tab>
-<Tab title="Windows">
+<Tab title="Windows (PowerShell)">
 ```powershell
 code $env:AppData\Claude\claude_desktop_config.json
 ```
@@ -359,7 +359,7 @@ mkdir src
 touch src/index.ts
 ```
 
-```powershell Windows
+```powershell Windows (PowerShell)
 # Create a new directory for our project
 md weather
 cd weather
@@ -779,7 +779,7 @@ For example, if you have [VS Code](https://code.visualstudio.com/) installed:
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 </Tab>
-<Tab title="Windows">
+<Tab title="Windows (PowerShell)">
 ```powershell
 code $env:AppData\Claude\claude_desktop_config.json
 ```


### PR DESCRIPTION
## Motivation and Context
It may not be clear to some readers that many of the commands intended for Windows are also intended for a PowerShell context, rather than a more traditional cmd.exe context. As such, it would be good to explicitly inform the user that PowerShell is the intended execution environment.

## How Has This Been Tested?
Yes

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed