### PR TITLE
Explains cause/solution for ${APPDATA} ENOENT

### DIFF
--- a/quickstart/user.mdx
+++ b/quickstart/user.mdx
@@ -194,6 +194,35 @@ type "%APPDATA%\Claude\logs\mcp*.log"
 <Accordion title="None of this is working. What do I do?">
   Please refer to our [debugging guide](/docs/tools/debugging) for better debugging tools and more detailed guidance.
 </Accordion>
+<Accordion title="ENOENT error and `${APPDATA}` in paths on Windows">
+If your configured server fails to load, and you see within its logs an error referring to `${APPDATA}` within a path, you may need to add the expanded value of `%APPDATA%` to your `env` key in `claude_desktop_config.json`:
+
+```json
+{
+  "brave-search": {
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+    "env": {
+      "APPDATA": "C:\\Users\\user\\AppData\\Roaming\\",
+      "BRAVE_API_KEY": "..."
+    }
+  }
+}
+```
+
+With this change in place, launch Claude Desktop once again.
+
+<Warning>
+**NPM should be installed globally**
+
+The `npx` command may continue to fail if you have not installed NPM globally. If NPM is already installed globally, you will find `%APPDATA%\npm` exists on your system. If not, you can install NPM globally by running the following command:
+
+```bash
+npm install -g npm
+```
+</Warning>
+
+</Accordion>
 </AccordionGroup>
 
 ## Next steps


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Some Windows users may not be able to easily configure and use MCP Servers. This appears to impact largely (if not exclusively) those users who installed Node via the official MSI installer. These users tend to report seeing `ENOENT` errors in their logs, as well as a literal instance of `${APPDATA}`  in the associated path.

**Note:** This PR is a proposal; I'm certain that the explanation and presentation can be improved upon. I submit this PR with the hopes that somebody else, with a fresh set of eyes, will evaluate the issue and contribute additional insight.

## Motivation and Context
After some investigation, I found that this problem arises when _npx_ determines where to install files, specifically when it attempts to construct the desired _prefix_. During this process Node loads `C:\Program Files\nodejs\node_modules\npm\npmrc` (not to be confused with `.npmrc` in the same directory). The contents of this file (i.e., `prefix=${APPDATA}\npm`) are then parsed, and the value is passed (_unexpanded_) to Node's `path.resolve` function, which concatenates the literal string `"${APPDATA}\npm"` onto `process.cwd()` (where claude.exe resides). This results in the malformed path.

## How Has This Been Tested?
I worked through the flow over the course of several hours. While I'm clear on the cause, I'm not sure if this behavior should be considered a bug on the part of npx/npm or if it merely merits clarification in the MCP documentation as an unfortunate quark.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed