### PR TITLE
Add OpenSumi to client and server list

### DIFF
--- a/clients.mdx
+++ b/clients.mdx
@@ -27,6 +27,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [TheiaAI/TheiaIDE][TheiaAI/TheiaIDE]        | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Agents in Theia AI and the AI-powered Theia IDE          |
 | [Windsurf Editor][Windsurf]                 | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools with AI Flow for collaborative development.                  |
 | [Zed][Zed]                                  | ❌          | ✅        | ❌      | ❌         | ❌    | Prompts appear as slash commands                                            |
+| [OpenSumi][OpenSumi]                        | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools in OpenSumi                                                  |
 
 [Claude]: https://claude.ai/download
 [Cursor]: https://cursor.com
@@ -214,6 +215,13 @@ Theia AI and Theia IDE's MCP integration provide users with flexibility, making 
 - Tool integration for enhanced coding workflows
 - Tight integration with editor features and workspace context
 - Does not support MCP resources
+
+### OpenSumi
+[OpenSumi](https://github.com/opensumi/core) is a framework helps you quickly build AI Native IDE products.
+
+**Key features:**
+- Supports MCP tools in OpenSumi
+- Supports built-in IDE MCP servers and custom MCP servers
 
 ## Adding MCP support to your application
 


### PR DESCRIPTION
Hi! I'm excited to share I've just added MCP support to [OpenSumi](https://github.com/opensumi/core). OpenSumi is a framework that helps you quickly build AI-native IDE products. It now supports MCP Client functionalities. With this, OpenSumi can support other third-party MCP Servers.

## Motivation and Context
OpenSumi added MCP support and this PR updates the clients and servers page.

## How Has This Been Tested?
YES

## Breaking Changes
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->

ScreenShots of OpenSumi MCP features: 
![image](https://github.com/user-attachments/assets/ffee56e5-7823-4d2c-9ed5-23367acd3995)

![image](https://github.com/user-attachments/assets/c8642def-0e79-4aed-a381-80492a96a162)

### Docs of OpenSumi MCP
https://github.com/opensumi/core/blob/main/packages/ai-native/MCP.md
