### PR TITLE
fix: improve mermaid diagram layout in architecture docs

### DIFF
--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -15,9 +15,10 @@ MCP follows a client-server architecture where:
 
 ```mermaid
 flowchart LR
-    subgraph "&nbsp;Host (e.g., Claude Desktop)&nbsp;"
-        client1[MCP Client]
-        client2[MCP Client]
+    subgraph "Host (e.g., Claude Desktop)"
+    Node["&nbsp;"]:::nodeStyle
+            client1[MCP Client]
+            client2[MCP Client]
     end
     subgraph "Server Process"
         server1[MCP Server]
@@ -25,6 +26,9 @@ flowchart LR
     subgraph "Server Process"
         server2[MCP Server]
     end
+
+
+  classDef nodeStyle height:0;
 
     client1 <-->|Transport Layer| server1
     client2 <-->|Transport Layer| server2


### PR DESCRIPTION
Within the graph, just added a space so the title can be visible.

![image](https://github.com/user-attachments/assets/2a77b8fd-f110-449a-9e4c-4e1ff67af511)

![image](https://github.com/user-attachments/assets/204f7a9f-f725-4226-aaf4-bddbfe9312f4)



## Motivation and Context
The title wasn't being shown entirely.

## How Has This Been Tested?
Using mintlify, just checked visualy.

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
