### PR TITLE
Fix Java SDK documentation where it's incosistent to API

### DIFF
--- a/sdk/java/mcp-server.mdx
+++ b/sdk/java/mcp-server.mdx
@@ -259,12 +259,25 @@ Supported logging levels (in order of increasing severity): DEBUG (0), INFO (1),
   <Tab title="Sync">
 ```java
 // Sync tool registration
+var schema = """
+            {
+              "type" : "object",
+              "id" : "urn:jsonschema:Operation",
+              "properties" : {
+                "operation" : {
+                  "type" : "string"
+                },
+                "a" : {
+                  "type" : "number"
+                },
+                "b" : {
+                  "type" : "number"
+                }
+              }
+            }
+            """;
 var syncToolRegistration = new McpServerFeatures.SyncToolRegistration(
-    new Tool("calculator", "Basic calculator", Map.of(
-        "operation", "string",
-        "a", "number",
-        "b", "number"
-    )),
+    new Tool("calculator", "Basic calculator", schema),
     arguments -> {
         // Tool implementation
         return new CallToolResult(result, false);
@@ -276,12 +289,25 @@ var syncToolRegistration = new McpServerFeatures.SyncToolRegistration(
   <Tab title="Async">
 ```java
 // Async tool registration
+var schema = """
+            {
+              "type" : "object",
+              "id" : "urn:jsonschema:Operation",
+              "properties" : {
+                "operation" : {
+                  "type" : "string"
+                },
+                "a" : {
+                  "type" : "number"
+                },
+                "b" : {
+                  "type" : "number"
+                }
+              }
+            }
+            """;
 var asyncToolRegistration = new McpServerFeatures.AsyncToolRegistration(
-    new Tool("calculator", "Basic calculator", Map.of(
-        "operation", "string",
-        "a", "number",
-        "b", "number"
-    )),
+    new Tool("calculator", "Basic calculator", schema),
     arguments -> {
         // Tool implementation
         return Mono.just(new CallToolResult(result, false));


### PR DESCRIPTION
## Motivation and Context

The documentation for the Java SDK was a little bit out of sync and led to few hurdles when trying to set up things quickly.

This PR changes the following things:

- Add an example for a JSON schema to the `Tool` class.

## Types of changes
- [x] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

