### PR TITLE
Fix broken link in client.mdx and server.mdx

### DIFF
--- a/quickstart/client.mdx
+++ b/quickstart/client.mdx
@@ -405,7 +405,7 @@ If you see:
 <Tab title="Java">
 
 <Note>
-This is a quickstart demo based on Spring AI MCP auto-configuration and boot starters. 
+This is a quickstart demo based on Spring AI MCP auto-configuration and boot starters.
 To learn how to create sync and async MCP Clients manually, consult the [Java SDK Client](/sdk/java/mcp-client) documentation
 </Note>
 
@@ -531,14 +531,14 @@ Key features:
 - Maintains conversation memory using InMemoryChatMemory
 - Runs as an interactive command-line application
 
-### Build and run 
+### Build and run
 
 ```bash
 ./mvnw clean install
 java -jar ./target/ai-mcp-brave-chatbot-0.0.1-SNAPSHOT.jar
 ```
 
-or 
+or
 
 ```bash
 ./mvnw spring-boot:run
@@ -596,7 +596,7 @@ This provides similar functionality but uses a WebFlux-based SSE transport imple
   <Card
     title="Building MCP with LLMs"
     icon="comments"
-    href="/building-mcp-with-llms"
+    href="/tutorials/building-mcp-with-llms"
   >
     Learn how to use LLMs like Claude to speed up your MCP development
   </Card>

--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -1165,7 +1165,7 @@ For more advanced troubleshooting, check out our guide on [Debugging MCP](/docs/
   <Card
     title="Building MCP with LLMs"
     icon="comments"
-    href="/building-mcp-with-llms"
+    href="/tutorials/building-mcp-with-llms"
   >
     Learn how to use LLMs like Claude to speed up your MCP development
   </Card>


### PR DESCRIPTION
The link to "Building MCP with LLMs" in `client.mdx` and `server.mdx` is broken. Fixing it to point to the correct path `/tutorials/building-mcp-with-llms`

## Motivation and Context
Fixes a broken link

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed
