### PR TITLE
fix typo in server.mdx

### DIFF
--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -303,6 +303,14 @@ In this case, we'll add our single weather server like so:
 
 <Warning>
 You may need to put the full path to the `uv` executable in the `command` field. You can get this by running `which uv` on MacOS/Linux or `where uv` on Windows.
+Replace the directory path with the absolute path to your weather project folder
+For macOS/Linux users: Use forward slashes in your path (e.g., /Users/username/projects/weather-app/weather)
+If uv is not in your PATH, specify the full path to the executable:
+
+Windows: "command": "C:\\Users\\YourUsername\\AppData\\Local\\Programs\\Python\\uv.exe"
+macOS: "command": "/Users/username/.local/bin/uv"
+
+The configuration defines a server named "weather" that will be managed by MCP
 </Warning>
 
 <Note>
@@ -311,7 +319,7 @@ Make sure you pass in the absolute path to your server.
 
 This tells Claude for Desktop:
 1. There's an MCP server named "weather"
-2. To launch it by running `uv --directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/weather run weather`
+2. To launch it by running `uv --directory /ABSOLUTE/PATH/TO/PARENT/FOLDER/weather run weather.py`
 
 Save the file, and restart **Claude for Desktop**.
 </Tab>


### PR DESCRIPTION
fixed the example typo for running server. and added detail example for uv command

<!-- Provide a brief summary of your changes -->

## Motivation and Context
1. Current server launch example command did not work and can confuse the developers who is trying to setup a MCP server. 
2. Given example for uv command in MCP server will not work for most the developers, so adding exact example how to add command to configure the weather server.


## How Has This Been Tested?
I have tested this there is minor typo for launch command example. and adding more detailed examples to setup the uv command 

## Breaking Changes
No breaking changes

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x ] I have added or updated documentation as needed


