### PR TITLE
Add Meilisearch mcp server to list of official integrations

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -45,6 +45,7 @@ These MCP servers are maintained by companies for their platforms:
 - **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy and manage resources on the Cloudflare developer platform
 - **[E2B](https://github.com/e2b-dev/mcp-server)** - Execute code in secure cloud sandboxes
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
+- **[Meilisearch](https://github.com/meilisearch/meilisearch-mcp)** - Interface with Meilisearch API for search, RAG & configuration
 - **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through Markdown notes in Obsidian vaults
 - **[Qdrant](https://github.com/qdrant/mcp-server-qdrant/)** - Implement semantic memory using the Qdrant vector search engine
 - **[Raygun](https://github.com/MindscapeHQ/mcp-server-raygun)** - Access crash reporting and monitoring data


### PR DESCRIPTION
Hey team 👋
I am adding the Meilisearch MCP server as an official integration. The server already supports tools which are an interface for the Meilisearch API which allows anyone to configure, index data & search through it with full-text, semantic & hybrid capabilities.

## Motivation and Context
Plugging a search engine API would allow any human or LLMs to index data in a structured or unstructured format to search through it with facets, geo-search, full-text, semantic & hybrid capabilities. It eases the way for a developer to configure and maintain their search infrastructure, and it allows more complex agentic workflows around search. 

## How Has This Been Tested?
With Claude desktop, and we can already index, configure and search through any Meilisearch instance

## Breaking Changes
Nope

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] I have added or updated documentation as needed

