### PR TITLE
Update the python client quickstart docs uv run path

### DIFF
--- a/quickstart/client.mdx
+++ b/quickstart/client.mdx
@@ -314,7 +314,7 @@ uv run client.py path/to/build/index.js # node server
 ```
 
 <Note>
-If you're continuing the weather tutorial from the server quickstart, your command might look something like this: `python client.py .../weather/src/weather/server.py`
+If you're continuing the weather tutorial from the server quickstart, your command might look something like this: `python client.py .../quickstart-resources/weather-server-python/weather.py`
 </Note>
 
 The client will:


### PR DESCRIPTION


## Motivation and Context
The current python quick start client docs point to the incorrect folder and file.  The sample project has since changed and the new folder structure of the mcp server for weather.py should be reflected in the run command in the docs.

## How Has This Been Tested?
Ran this command with the correct path from the cloned quick-start repo.

The new path in the mcp server weather sample is: ../quickstart-resources/weather-server-python/weather.py

## Breaking Changes
No.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation update



