### PR TITLE
docs(clients.mdx): add think-mcp-host to supported applications list

### DIFF
--- a/clients.mdx
+++ b/clients.mdx
@@ -31,6 +31,7 @@ This page provides an overview of applications that support the Model Context Pr
 | [SpinAI][SpinAI]                            | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools for Typescript AI Agents                                     |
 | [OpenSumi][OpenSumi]                        | ❌          | ❌        | ✅      | ❌         | ❌    | Supports tools in OpenSumi                                                  |
 | [Daydreams Agents][Daydreams]              | ✅          | ✅        | ✅      | ❌         | ❌    | Support for drop in Servers to Daydreams agents                             |
+| [think-mcp-host][think-mcp-host]            | ✅          | ✅        | ✅      | ❌         | ❌    | Full support for all MCP features                             |
 
 [Claude]: https://claude.ai/download
 [Cursor]: https://cursor.com
@@ -58,6 +59,7 @@ This page provides an overview of applications that support the Model Context Pr
 [Prompts]: https://modelcontextprotocol.io/docs/concepts/prompts
 [Tools]: https://modelcontextprotocol.io/docs/concepts/tools
 [Sampling]: https://modelcontextprotocol.io/docs/concepts/sampling
+[think-mcp-host]: https://github.com/thinkthinking/think-mcp-host
 
 ## Client details
 
@@ -252,6 +254,16 @@ Theia AI and Theia IDE's MCP integration provide users with flexibility, making 
 **Key features:**
 - Supports MCP Servers in config
 - Exposes MCP Client
+
+### think-mcp-host
+[think-mcp-host](https://github.com/thinkthinking/think-mcp-host) is an intelligent agent application based on Model Context Protocol (MCP) that supports various types of large language models. It features a command-line interface for seamless interaction, allowing users to engage with AI models through intuitive terminal commands.
+It can help you work with AI in a zen-like and loving mindset, hoping to bring you inspiration, joy, and peace.
+
+**Key features:**
+- Full support for MCP architecture (Host/Client/Server)
+- Comprehensive support for all MCP resource types (Resources, Prompts, Tools)
+- Dynamic MCP command insertion anywhere in conversations
+- Standalone MCP tool execution support
 
 ## Adding MCP support to your application
 


### PR DESCRIPTION
Adding think-mcp-host to supported applications list.
[think-mcp-host](https://github.com/thinkthinking/think-mcp-host) is an intelligent agent application based on Model Context Protocol (MCP) that supports various types of large language models. It features a command-line interface for seamless interaction, allowing users to engage with AI models through intuitive terminal commands.
It can help you work with AI in a zen-like and loving mindset, hoping to bring you inspiration, joy, and peace.

**Key features:**
- Full support for MCP architecture (Host/Client/Server)
- Comprehensive support for all MCP resource types (Resources, Prompts, Tools)
- Dynamic MCP command insertion anywhere in conversations
- Standalone MCP tool execution support
