### PR TITLE
refactor: update Spring AI artifact IDs to new naming convention

### DIFF
--- a/quickstart/client.mdx
+++ b/quickstart/client.mdx
@@ -859,11 +859,11 @@ The application integrates Spring AI with the Brave Search MCP server through se
 ```xml
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mcp-client-spring-boot-starter</artifactId>
+    <artifactId>spring-ai-starter-mcp-client</artifactId>
 </dependency>
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-anthropic-spring-boot-starter</artifactId>
+    <artifactId>spring-ai-starter-model-anthropic</artifactId>
 </dependency>
 ```
 
@@ -885,7 +885,7 @@ spring:
       api-key: ${ANTHROPIC_API_KEY}
 ```
 
-This activates the `spring-ai-mcp-client-spring-boot-starter` to create one or more `McpClient`s based on the provided server configuration.
+This activates the `spring-ai-starter-mcp-client` to create one or more `McpClient`s based on the provided server configuration.
 
 3. MCP Server Configuration (`mcp-servers-config.json`):
 ```json

--- a/quickstart/server.mdx
+++ b/quickstart/server.mdx
@@ -775,7 +775,7 @@ You will need to add the following dependencies:
   <dependencies>
         <dependency>
             <groupId>org.springframework.ai</groupId>
-            <artifactId>spring-ai-mcp-server-spring-boot-starter</artifactId>
+            <artifactId>spring-ai-starter-mcp-server</artifactId>
         </dependency>
 
         <dependency>
@@ -788,7 +788,7 @@ You will need to add the following dependencies:
   <Tab title="Gradle">
   ```groovy
   dependencies {
-    implementation platform("org.springframework.ai:spring-ai-mcp-server-spring-boot-starter")
+    implementation platform("org.springframework.ai:spring-ai-starter-mcp-server")
     implementation platform("org.springframework:spring-web")   
   }
   ```
@@ -1011,12 +1011,12 @@ mcpClient.closeGracefully();
 
 ### Use MCP Client Boot Starter
 
-Create a new boot starter applicaiton using the `spring-ai-mcp-client-spring-boot-starter` dependency:
+Create a new boot starter applicaiton using the `spring-ai-starter-mcp-client` dependency:
 
 ```xml
 <dependency>
     <groupId>org.springframework.ai</groupId>
-    <artifactId>spring-ai-mcp-client-spring-boot-starter</artifactId>
+    <artifactId>spring-ai-starter-mcp-client</artifactId>
 </dependency>
 ```
 


### PR DESCRIPTION
Update Spring AI dependency artifact IDs in documentation to follow the new naming convention:

- spring-ai-mcp-client-spring-boot-starter → spring-ai-starter-mcp-client
- spring-ai-anthropic-spring-boot-starter → spring-ai-starter-model-anthropic
- spring-ai-mcp-server-spring-boot-starter → spring-ai-starter-mcp-server

This is to align the quickstart documentation with the changes to be released with Spring-AI 1.0.0-M7

