### PR TITLE
Add link to Anthropic support docs instead of email

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -181,4 +181,4 @@ Here's how to get help or provide feedback:
 - For bug reports and feature requests related to the MCP specification, SDKs, or documentation (open source), please [create a GitHub issue](https://github.com/modelcontextprotocol)
 - For discussions or Q&A about the MCP specification, use the [specification discussions](https://github.com/modelcontextprotocol/specification/discussions)
 - For discussions or Q&A about other MCP open source components, use the [organization discussions](https://github.com/orgs/modelcontextprotocol/discussions)
-- For bug reports, feature requests, and questions related to Claude.app and claude.ai's MCP integration, please email mcp-support@anthropic.com
+- For bug reports, feature requests, and questions related to Claude.app and claude.ai's MCP integration, please see Anthropic's guide on [How to Get Support](https://support.anthropic.com/en/articles/9015913-how-to-get-support)


### PR DESCRIPTION
This email address is no longer the preferred way to get Anthropic support on MCP features.