### PR TITLE
Fix `python` snippet in `Core architecture`

### DIFF
--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -267,7 +267,7 @@ Here's a basic example of implementing an MCP server:
             )
 
     if __name__ == "__main__":
-        asyncio.run(main)
+        asyncio.run(main())
     ```
   </Tab>
 </Tabs>


### PR DESCRIPTION
`asyncio.run` expects a coroutine, not a function.

## Motivation and Context
Running the example errors with:
```
    asyncio.run(main)
    ~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.2/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 89, in run
    raise ValueError("a coroutine was expected, got {!r}".format(coro))
ValueError: a coroutine was expected, got <function main at 0x105a8fce0>
```

## How Has This Been Tested?
Ran the fix.

## Breaking Changes
No

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
n/a
