### PR TITLE
docs(java): clarify core vs optional transport implementations

### DIFF
--- a/sdk/java/mcp-client.mdx
+++ b/sdk/java/mcp-client.mdx
@@ -15,9 +15,10 @@ The MCP Client is a key component in the Model Context Protocol (MCP) architectu
 - Prompt system interactions
 - Optional features like roots management and sampling support
 
-<Tip> 
-The [Spring-AI MCP Client](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html) integration extends the MCP Java SDK to 
-provide auto-configuration for MCP client functionality in Spring Boot applications and integrating with Spring AI’s [tool execution framework](https://docs.spring.io/spring-ai/reference/api/tools.html).
+<Tip>
+The core `io.modelcontextprotocol.sdk:mcp` module provides STDIO and SSE client transport implementations  without requiring external web frameworks. 
+
+Spring-specific transport implementations are available as an **optional** dependency `io.modelcontextprotocol.sdk:mcp-spring-webflux` for [Spring Framework](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html) users.
 </Tip>
 
 The client provides both synchronous and asynchronous APIs for flexibility in different application contexts.

--- a/sdk/java/mcp-overview.mdx
+++ b/sdk/java/mcp-overview.mdx
@@ -22,18 +22,20 @@ If you're upgrading from 0.7.0, please refer to the [Migration Guide](https://gi
   - [Prompt](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/prompts/) handling and management
   - [Sampling](https://spec.modelcontextprotocol.io/specification/2024-11-05/client/sampling/) support for AI model interactions
 - Multiple transport implementations:
-  - Default transports:
+  - Default transports (included in core `mcp` module, no external web frameworks required):
     - Stdio-based transport for process-based communication
     - Java HttpClient-based SSE client transport for HTTP SSE Client-side streaming
     - Servlet-based SSE server transport for HTTP SSE Server streaming
-  - Spring-based transports:
+  - Optional Spring-based transports (convenience if using Spring Framework):
     - WebFlux SSE client and server transports for reactive HTTP streaming
     - WebMVC SSE transport for servlet-based HTTP streaming
 - Supports Synchronous and Asynchronous programming paradigms
 
-<Tip>[Spring AI MCP](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-overview.html) extends the MCP Java SDK with Spring Boot integration, 
-providing both [Client](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html) and [Server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html) Boot Starters. 
-You can bootstrap your AI Spring applications using the [Spring Initializer](https://start.spring.io/).</Tip>
+<Tip>
+The core `io.modelcontextprotocol.sdk:mcp` module provides default STDIO and SSE client and server transport implementations without requiring external web frameworks. 
+
+Spring-specific transports are available as optional dependencies for convenience when using the [Spring Framework](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html).
+</Tip>
 
 ## Architecture
 
@@ -80,16 +82,18 @@ The core MCP functionality:
 </dependency>
 ```
 
-For HTTP SSE transport implementations, add one of the following dependencies:
+The core `mcp` module already includes default STDIO and SSE transport implementations and doesn't require external web frameworks.
+
+If you're using the Spring Framework and want to use Spring-specific transport implementations, add one of the following optional dependencies:
 
 ```xml
-<!-- Spring WebFlux-based SSE client and server transport -->
+<!-- Optional: Spring WebFlux-based SSE client and server transport -->
 <dependency>
     <groupId>io.modelcontextprotocol.sdk</groupId>
     <artifactId>mcp-spring-webflux</artifactId>
 </dependency>
 
-<!-- Spring WebMVC-based SSE server transport -->
+<!-- Optional: Spring WebMVC-based SSE server transport -->
 <dependency>
     <groupId>io.modelcontextprotocol.sdk</groupId>
     <artifactId>mcp-spring-webmvc</artifactId>
@@ -106,15 +110,17 @@ For HTTP SSE transport implementations, add one of the following dependencies:
   }
   ```
 
-    For HTTP SSE transport implementations, add one of the following dependencies:
+    The core `mcp` module already includes default STDIO and SSE transport implementations and doesn't require external web frameworks.
+
+    If you're using the Spring Framework and want to use Spring-specific transport implementations, add one of the following optional dependencies:
 
     ```groovy
-    // Spring WebFlux-based SSE client and server transport
+    // Optional: Spring WebFlux-based SSE client and server transport
     dependencies {
       implementation platform("io.modelcontextprotocol.sdk:mcp-spring-webflux")
     }
 
-    // Spring WebMVC-based SSE server transport
+    // Optional: Spring WebMVC-based SSE server transport
     dependencies {
       implementation platform("io.modelcontextprotocol.sdk:mcp-spring-webmvc")
     }
@@ -169,10 +175,9 @@ Replace the version number with the version of the BOM you want to use.
 The following dependencies are available and managed by the BOM:
 
 - Core Dependencies 
-  - `io.modelcontextprotocol.sdk:mcp` - Core MCP library providing the base functionality and APIs for Model Context Protocol implementation.
-- Transport Dependencies
+  - `io.modelcontextprotocol.sdk:mcp` - Core MCP library providing the base functionality and APIs for Model Context Protocol implementation, including default STDIO and SSE client and server transport implementations. No external web frameworks required.
+- Optional Transport Dependencies (convenience if using Spring Framework)
   - `io.modelcontextprotocol.sdk:mcp-spring-webflux` - WebFlux-based Server-Sent Events (SSE) transport implementation for reactive applications.
   - `io.modelcontextprotocol.sdk:mcp-spring-webmvc` - WebMVC-based Server-Sent Events (SSE) transport implementation for servlet-based applications.
 - Testing Dependencies
   - `io.modelcontextprotocol.sdk:mcp-test` - Testing utilities and support for MCP-based applications.
-

--- a/sdk/java/mcp-server.mdx
+++ b/sdk/java/mcp-server.mdx
@@ -21,10 +21,12 @@ The MCP Server is a foundational component in the Model Context Protocol (MCP) a
 - Managing concurrent client connections
 - Providing structured logging and notifications
 
-<Tip> 
-The [Spring-AI MCP Server](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-server-boot-starter-docs.html) integration extends the MCP Java SDK to 
-provide auto-configuration for MCP server functionality in Spring Boot applications.
+<Tip>
+The core `io.modelcontextprotocol.sdk:mcp` module provides STDIO and SSE server transport implementations  without requiring external web frameworks. 
+
+Spring-specific transport implementations are available as an **optional** dependencies `io.modelcontextprotocol.sdk:mcp-spring-webflux`, `io.modelcontextprotocol.sdk:mcp-spring-webmvc` for [Spring Framework](https://docs.spring.io/spring-ai/reference/api/mcp/mcp-client-boot-starter-docs.html) users.
 </Tip>
+
 
 The server supports both synchronous and asynchronous APIs, allowing for flexible integration in different application contexts.
 


### PR DESCRIPTION
- Emphasize that core mcp module includes default STDIO and SSE transport implementations
- Clarify that default implementations don't require external web frameworks
- Mark Spring-specific transport implementations as optional dependencies