### PR TITLE
Add Zapier MCP to additional resources

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -122,5 +122,6 @@ To use an MCP server with Claude, add it to your configuration:
 - [MCP CLI](https://github.com/wong2/mcp-cli) - Command-line inspector for testing MCP servers
 - [MCP Get](https://mcp-get.com) - Tool for installing and managing MCP servers
 - [Supergateway](https://github.com/supercorp-ai/supergateway) - Run MCP stdio servers over SSE
+- [Zapier MCP](https://zapier.com/mcp) - MCP Server with over 7,000+ apps and 30,000+ actions
 
 Visit our [GitHub Discussions](https://github.com/orgs/modelcontextprotocol/discussions) to engage with the MCP community.


### PR DESCRIPTION
Adds Zapier MCP to the Additional Resources section on examples page.

## Motivation and Context
Zapier's MCP provides by far the largest library of MCP tools as one server.

## How Has This Been Tested?
Yes.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

