### PR TITLE
Add Edgee MCP server to the official integration list

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -44,6 +44,7 @@ These MCP servers are maintained by companies for their platforms:
 - **[Browserbase](https://github.com/browserbase/mcp-server-browserbase)** - Automate browser interactions in the cloud
 - **[Cloudflare](https://github.com/cloudflare/mcp-server-cloudflare)** - Deploy and manage resources on the Cloudflare developer platform
 - **[E2B](https://github.com/e2b-dev/mcp-server)** - Execute code in secure cloud sandboxes
+- **[Edgee](https://github.com/edgee-cloud/mcp-server-edgee)** - Deploy and manage Edgee components and projects
 - **[Neon](https://github.com/neondatabase/mcp-server-neon)** - Interact with the Neon serverless Postgres platform
 - **[Obsidian Markdown Notes](https://github.com/calclavia/mcp-obsidian)** - Read and search through Markdown notes in Obsidian vaults
 - **[Qdrant](https://github.com/qdrant/mcp-server-qdrant/)** - Implement semantic memory using the Qdrant vector search engine


### PR DESCRIPTION
## Motivation and Context
[Edgee](https://www.edgee.cloud) is an Edge Component Platform. We support the MCP initiative and believe that edge computing world can benefit from this innovation, and vice versa. 
We have developed our own MCP server and would like to see it included in the official integration list.

## How Has This Been Tested?
This PR is a simple doc adjustment

## Breaking Changes
No breaking change

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

