### PR TITLE
MCP Access to federated data via MindsDB

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -14,6 +14,7 @@ These official reference servers demonstrate core MCP features and SDK usage:
 - **[PostgreSQL](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)** - Read-only database access with schema inspection capabilities
 - **[SQLite](https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite)** - Database interaction and business intelligence features
 - **[Google Drive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive)** - File access and search capabilities for Google Drive
+- **[MindsDB](https://github.com/modelcontextprotocol/servers/tree/main/src/mindsdb)** - MindsDB's federated query engine enables data access across [various data platforms](https://docs.mindsdb.com/integrations/data-overview)
 
 ### Development tools
 - **[Git](https://github.com/modelcontextprotocol/servers/tree/main/src/git)** - Tools to read, search, and manipulate Git repositories


### PR DESCRIPTION

## Motivation and Context

MindsDB has been added to MCP servers in [this PR](https://github.com/modelcontextprotocol/servers/pull/1180).

This PR adds MindsDB to the list in the documentation.

## Types of changes

- [ ] Documentation update
