### PR TITLE
fix: await and param key name

### DIFF
--- a/quickstart/client.mdx
+++ b/quickstart/client.mdx
@@ -565,14 +565,14 @@ async connectToServer(serverScriptPath: string) {
       command,
       args: [serverScriptPath],
     });
-    this.mcp.connect(this.transport);
+    await this.mcp.connect(this.transport);
     
     const toolsResult = await this.mcp.listTools();
     this.tools = toolsResult.tools.map((tool) => {
       return {
         name: tool.name,
         description: tool.description,
-        input_schema: tool.inputSchema,
+        inputSchema: tool.inputSchema,
       };
     });
     console.log(


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

1. Add `await` for `this.mcp.connect` since it returns a Promise.
2. use `inputSchema` instead of `input_schema` (fix type)

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

1. Without `await`, an error will occur when calling `getTools` because the connection has not been established yet.
2. In the Node MCP SDK, the type definition for Tool is `inputSchema`, not `input_schema`.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

Fix and run it

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

no

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
