### PR TITLE
Fix docstring for python code block

### DIFF
--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -62,9 +62,7 @@ The protocol layer handles message framing, request/response linking, and high-l
             request: RequestT,
             result_type: type[Result]
         ) -> Result:
-            """
-            Send request and wait for response. Raises McpError if response contains error.
-            """
+            """Send request and wait for response. Raises McpError if response contains error."""
             # Request handling implementation
 
         async def send_notification(


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Removed the extra spacing after the `"""` in the python code block [here](https://modelcontextprotocol.io/docs/concepts/architecture#protocol-layer) in order to fix the syntax highlighting

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->

After making the change, I ran `mintlify dev` to ensure that the fix worked. On the left is the docs before the change and on the right are the docs on my local machine after the change:

<img width="1724" alt="Screenshot 2025-04-08 at 9 50 44 AM" src="https://github.com/user-attachments/assets/55826e19-eafc-49c8-a5fc-83549ef276c7" />

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
None
